### PR TITLE
Injects the editor in the executor context

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -16,6 +16,8 @@ repositories {
 dependencies {
   implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.17.0")
   implementation("io.github.furstenheim:copy_down:1.1")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+  testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.8.2")
 }
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
@@ -39,11 +41,6 @@ tasks.register<RunIdeTask>("plainIdea") {
 
 tasks {
   test {
-    dependencies {
-      testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
-      testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.8.2")
-    }
-
     jvmArgs = listOf(
       "--add-opens=java.base/java.lang=ALL-UNNAMED",
       "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",

--- a/server/src/main/java/org/rri/ideals/server/codeactions/ActionData.java
+++ b/server/src/main/java/org/rri/ideals/server/codeactions/ActionData.java
@@ -5,7 +5,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-final class ActionData {
+public final class ActionData {
   private String uri;
   private Range range;
 

--- a/server/src/main/java/org/rri/ideals/server/commands/ExecutorContext.java
+++ b/server/src/main/java/org/rri/ideals/server/commands/ExecutorContext.java
@@ -1,6 +1,7 @@
 package org.rri.ideals.server.commands;
 
-import com.intellij.openapi.project.Project;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiFile;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.jetbrains.annotations.NotNull;
@@ -11,13 +12,16 @@ final public class ExecutorContext {
   @NotNull
   private final PsiFile file;
   @NotNull
-  private final Project project;
+  private final Disposable disposable;
   @Nullable
   private final CancelChecker cancelToken;
+  @Nullable
+  private final Editor editor;
 
-  public ExecutorContext(@NotNull PsiFile file, @NotNull Project project, @Nullable CancelChecker cancelToken) {
+  public ExecutorContext(@NotNull PsiFile file, @NotNull Disposable disposable, @Nullable Editor editor, @Nullable CancelChecker cancelToken) {
     this.file = file;
-    this.project = project;
+    this.editor = editor;
+    this.disposable = disposable;
     this.cancelToken = cancelToken;
   }
 
@@ -25,11 +29,15 @@ final public class ExecutorContext {
     return file;
   }
 
-  public @NotNull Project getProject() {
-    return project;
-  }
-
   public @Nullable CancelChecker getCancelToken() {
     return cancelToken;
+  }
+
+  public @Nullable Editor getEditor() {
+    return editor;
+  }
+
+  public @NotNull Disposable getDisposable() {
+    return disposable;
   }
 }

--- a/server/src/main/java/org/rri/ideals/server/commands/LspCommand.java
+++ b/server/src/main/java/org/rri/ideals/server/commands/LspCommand.java
@@ -1,19 +1,14 @@
 package org.rri.ideals.server.commands;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.util.concurrency.AppExecutorUtil;
-import org.eclipse.lsp4j.jsonrpc.CancelChecker;
-import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.rri.ideals.server.LspPath;
-import org.rri.ideals.server.util.MiscUtil;
+import org.rri.ideals.server.util.AsyncExecutor;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 public abstract class LspCommand<R> {
@@ -26,34 +21,22 @@ public abstract class LspCommand<R> {
 
   protected abstract R execute(@NotNull ExecutorContext ctx);
 
-  public @NotNull CompletableFuture<@Nullable R> runAsync(@NotNull Project project, @NotNull LspPath path) {
-    final var virtualFile = path.findVirtualFile();
-    if (virtualFile == null) {
-      LOG.info("File not found: " + path);
-      // todo mb need to throw excep
-      return CompletableFuture.completedFuture(null);
-    }
-
-    LOG.info(getMessageSupplier().get());
-    Executor executor = AppExecutorUtil.getAppExecutorService();
-    if (isCancellable()) {
-      return CompletableFutures.computeAsync(executor, cancelToken -> getResult(path, project, cancelToken));
-    } else {
-      return CompletableFuture.supplyAsync(() -> getResult(path, project, null), executor);
-    }
+  public @NotNull CompletableFuture<@Nullable R> runAsync(@NotNull Project project, @NotNull TextDocumentIdentifier textDocumentIdentifier) {
+    return runAsync(project, textDocumentIdentifier.getUri(), null);
   }
 
-  private @Nullable R getResult(@NotNull LspPath path,
-                                @NotNull Project project,
-                                @Nullable CancelChecker cancelToken) {
-    final AtomicReference<R> ref = new AtomicReference<>();
-    ApplicationManager.getApplication()
-        .invokeAndWait(
-            () -> ref.set(MiscUtil.produceWithPsiFileInReadAction(
-                project,
-                path,
-                (psiFile) -> execute(new ExecutorContext(psiFile, project, cancelToken))
-            )));
-    return ref.get();
+  public @NotNull CompletableFuture<@Nullable R> runAsync(@NotNull Project project, @NotNull TextDocumentIdentifier textDocumentIdentifier, @Nullable Position position) {
+    return runAsync(project, textDocumentIdentifier.getUri(), position);
+  }
+
+  public @NotNull CompletableFuture<@Nullable R> runAsync(@NotNull Project project, @NotNull String uri, @Nullable Position position) {
+    LOG.info(getMessageSupplier().get());
+    var client = AsyncExecutor.<R>builder()
+        .executorContext(project, uri, position)
+        .cancellable(isCancellable())
+        .runInEDT(true)
+        .build();
+
+    return client.compute(this::execute);
   }
 }

--- a/server/src/main/java/org/rri/ideals/server/formatting/FormattingCommand.java
+++ b/server/src/main/java/org/rri/ideals/server/formatting/FormattingCommand.java
@@ -52,7 +52,7 @@ final public class FormattingCommand extends FormattingCommandBase {
     CommandProcessor
         .getInstance()
         .executeCommand(
-            context.getProject(),
+            psiFile.getProject(),
             () -> doWithTemporaryCodeStyleSettingsForFile(
                 psiFile,
                 () -> doReformat(psiFile, getConfiguredTextRange(psiFile))),

--- a/server/src/main/java/org/rri/ideals/server/formatting/OnTypeFormattingCommand.java
+++ b/server/src/main/java/org/rri/ideals/server/formatting/OnTypeFormattingCommand.java
@@ -59,32 +59,27 @@ public class OnTypeFormattingCommand extends FormattingCommandBase {
   }
 
   void typeAndReformatIfNeededInFile(@NotNull PsiFile psiFile) {
-    var disposable = Disposer.newDisposable();
-    try {
-      EditorUtil.withEditor(disposable, psiFile, position, editor -> {
-        var doc = MiscUtil.getDocument(psiFile);
-        assert doc != null;
-        ApplicationManager.getApplication().runWriteAction(() -> {
-          if (!deleteTypedChar(editor, doc)) {
-            return;
-          }
-          PsiDocumentManager.getInstance(psiFile.getProject()).commitDocument(doc);
+    EditorUtil.withEditor(Disposer.newDisposable(), psiFile, position, editor -> {
+      var doc = MiscUtil.getDocument(psiFile);
+      assert doc != null;
+      ApplicationManager.getApplication().runWriteAction(() -> {
+        if (!deleteTypedChar(editor, doc)) {
+          return;
+        }
+        PsiDocumentManager.getInstance(psiFile.getProject()).commitDocument(doc);
 
-          if (editor instanceof EditorEx) {
-            ((EditorEx) editor).setHighlighter(
-                HighlighterFactory.createHighlighter(psiFile.getProject(), psiFile.getFileType()));
-          }
-          doWithTemporaryCodeStyleSettingsForFile(
-              psiFile,
-              () -> TypedAction.getInstance().actionPerformed(
-                  editor,
-                  triggerCharacter,
-                  com.intellij.openapi.editor.ex.util.EditorUtil.getEditorDataContext(editor)));
-        });
+        if (editor instanceof EditorEx) {
+          ((EditorEx) editor).setHighlighter(
+              HighlighterFactory.createHighlighter(psiFile.getProject(), psiFile.getFileType()));
+        }
+        doWithTemporaryCodeStyleSettingsForFile(
+            psiFile,
+            () -> TypedAction.getInstance().actionPerformed(
+                editor,
+                triggerCharacter,
+                com.intellij.openapi.editor.ex.util.EditorUtil.getEditorDataContext(editor)));
       });
-    } finally {
-      Disposer.dispose(disposable);
-    }
+    });
   }
 
   private boolean deleteTypedChar(@NotNull Editor editor, @NotNull Document doc) {

--- a/server/src/main/java/org/rri/ideals/server/references/FindDefinitionCommand.java
+++ b/server/src/main/java/org/rri/ideals/server/references/FindDefinitionCommand.java
@@ -3,7 +3,6 @@ package org.rri.ideals.server.references;
 import com.intellij.codeInsight.TargetElementUtil;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiElement;
-import org.eclipse.lsp4j.Position;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Supplier;
@@ -11,9 +10,6 @@ import java.util.stream.Stream;
 
 
 public class FindDefinitionCommand extends FindDefinitionCommandBase {
-  public FindDefinitionCommand(@NotNull Position pos) {
-    super(pos);
-  }
 
   @Override
   protected @NotNull Supplier<@NotNull String> getMessageSupplier() {

--- a/server/src/main/java/org/rri/ideals/server/references/FindImplementationCommand.java
+++ b/server/src/main/java/org/rri/ideals/server/references/FindImplementationCommand.java
@@ -5,7 +5,6 @@ import com.intellij.codeInsight.navigation.ImplementationSearcher;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiElement;
-import org.eclipse.lsp4j.Position;
 import org.jetbrains.annotations.NotNull;
 import org.rri.ideals.server.util.MiscUtil;
 
@@ -13,9 +12,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class FindImplementationCommand extends FindDefinitionCommandBase {
-  public FindImplementationCommand(@NotNull Position pos) {
-    super(pos);
-  }
 
   @Override
   protected @NotNull Supplier<@NotNull String> getMessageSupplier() {

--- a/server/src/main/java/org/rri/ideals/server/references/FindTypeDefinitionCommand.java
+++ b/server/src/main/java/org/rri/ideals/server/references/FindTypeDefinitionCommand.java
@@ -3,7 +3,6 @@ package org.rri.ideals.server.references;
 import com.intellij.codeInsight.navigation.actions.GotoTypeDeclarationAction;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiElement;
-import org.eclipse.lsp4j.Position;
 import org.jetbrains.annotations.NotNull;
 import org.rri.ideals.server.util.MiscUtil;
 
@@ -11,9 +10,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class FindTypeDefinitionCommand extends FindDefinitionCommandBase {
-  public FindTypeDefinitionCommand(@NotNull Position pos) {
-    super(pos);
-  }
 
   @Override
   protected @NotNull Supplier<@NotNull String> getMessageSupplier() {

--- a/server/src/main/java/org/rri/ideals/server/util/AsyncExecutor.java
+++ b/server/src/main/java/org/rri/ideals/server/util/AsyncExecutor.java
@@ -1,0 +1,105 @@
+package org.rri.ideals.server.util;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.concurrency.AppExecutorUtil;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.rri.ideals.server.LspPath;
+import org.rri.ideals.server.commands.ExecutorContext;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+public class AsyncExecutor<R> {
+  private final boolean cancellable;
+  private final boolean runInEDT;
+  private final Executor executor = AppExecutorUtil.getAppExecutorService();
+  @Nullable
+  private final PsiFile psiFile;
+  private final Project project;
+  @Nullable
+  private final Position position;
+
+  private AsyncExecutor(@NotNull Builder<R> builder) {
+    this.cancellable = builder.cancellable;
+    this.psiFile = builder.psiFile;
+    this.project = builder.project;
+    this.position = builder.position;
+    this.runInEDT = builder.runInEDT;
+  }
+
+  public static <R> Builder<R> builder() {
+    return new AsyncExecutor.Builder<R>();
+  }
+
+  public @NotNull CompletableFuture<@Nullable R> compute(@NotNull Function<ExecutorContext, R> action) {
+    if (cancellable) {
+      return CompletableFutures.computeAsync(executor, cancelToken -> getResult(action, cancelToken));
+    } else {
+      return CompletableFuture.supplyAsync(() -> getResult(action, null), executor);
+    }
+  }
+
+  private @Nullable R getResult(@NotNull Function<ExecutorContext, R> action,
+                                @Nullable CancelChecker cancelToken) {
+    if (psiFile == null) {
+      return null;
+    }
+
+    final var disposable = Disposer.newDisposable();
+    final var editor = Optional.ofNullable(position)
+        .map(pos -> MiscUtil.computeInEDTAndWait(() -> EditorUtil.createEditor(disposable, psiFile, pos)))
+        .orElse(null);
+    final var context = new ExecutorContext(psiFile, disposable, editor, cancelToken);
+
+    try {
+      if (runInEDT) {
+        return MiscUtil.computeInEDTAndWait(() -> action.apply(context));
+      } else {
+        return action.apply(context);
+      }
+    } finally {
+      ApplicationManager.getApplication().invokeAndWait(() -> Disposer.dispose(disposable));
+      if (cancelToken != null) {
+        cancelToken.checkCanceled();
+      }
+    }
+  }
+
+  public static class Builder<R> {
+    private boolean cancellable = false;
+    private boolean runInEDT = false;
+    private Project project;
+    private Position position;
+    private PsiFile psiFile;
+
+    public Builder<R> cancellable(boolean cancellable) {
+      this.cancellable = cancellable;
+      return this;
+    }
+
+    public Builder<R> executorContext(@NotNull Project project, @NotNull String uri, @Nullable Position position) {
+      this.project = project;
+      this.psiFile = MiscUtil.resolvePsiFile(project, LspPath.fromLspUri(uri));
+      this.position = position;
+      return this;
+    }
+
+    public Builder<R> runInEDT(boolean runInEDT) {
+      this.runInEDT = runInEDT;
+      return this;
+    }
+
+    public AsyncExecutor<R> build() {
+      return new AsyncExecutor<>(this);
+    }
+  }
+}

--- a/server/src/main/java/org/rri/ideals/server/util/EditorUtil.java
+++ b/server/src/main/java/org/rri/ideals/server/util/EditorUtil.java
@@ -61,6 +61,8 @@ public class EditorUtil {
       return callback.apply(editor);
     } catch (Exception e) {
       throw MiscUtil.wrap(e);
+    } finally {
+      Disposer.dispose(context);
     }
   }
 

--- a/server/src/main/java/org/rri/ideals/server/util/MiscUtil.java
+++ b/server/src/main/java/org/rri/ideals/server/util/MiscUtil.java
@@ -7,7 +7,10 @@ import com.intellij.openapi.editor.impl.DocumentImpl;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.impl.FileDocumentManagerImpl;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.*;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.Ref;
+import com.intellij.openapi.util.Segment;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
@@ -22,6 +25,7 @@ import org.rri.ideals.server.LspPath;
 
 import java.util.Arrays;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -87,6 +91,16 @@ public class MiscUtil {
           block.accept(psiFile);
           return null;
         });
+  }
+
+  public static <T> T computeInEDTAndWait(@NotNull Supplier<T> action) {
+    final var ref = new AtomicReference<T>();
+
+    ApplicationManager.getApplication().invokeAndWait(() -> {
+      ref.set(action.get());
+    });
+
+    return ref.get();
   }
 
   @Nullable

--- a/server/src/test/java/org/rri/ideals/server/formatting/FormattingCommandTest.java
+++ b/server/src/test/java/org/rri/ideals/server/formatting/FormattingCommandTest.java
@@ -1,6 +1,7 @@
 package org.rri.ideals.server.formatting;
 
 import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.util.Disposer;
 import com.jetbrains.python.PythonFileType;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -172,7 +173,7 @@ public class FormattingCommandTest extends LspLightBasePlatformTestCase {
                                                                @Nullable Range lspRange) {
     final var actualPsiFile = myFixture.configureByText(fileType, actualText);
 
-    var context = new ExecutorContext(actualPsiFile, getProject(), new TestUtil.DumbCancelChecker());
+    var context = new ExecutorContext(actualPsiFile, Disposer.newDisposable(), null, new TestUtil.DumbCancelChecker());
     var command = new FormattingCommand(lspRange, FormattingTestUtil.defaultOptions());
 
     return TextUtil.differenceAfterAction(actualPsiFile, (copy) -> {

--- a/server/src/test/java/org/rri/ideals/server/references/DefinitionCommandTest.java
+++ b/server/src/test/java/org/rri/ideals/server/references/DefinitionCommandTest.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.rri.ideals.server.LspPath;
 import org.rri.ideals.server.TestUtil;
 import org.rri.ideals.server.engine.TestEngine;
 import org.rri.ideals.server.generator.IdeaOffsetPositionConverter;
@@ -18,7 +17,7 @@ import java.util.Set;
 
 
 @RunWith(JUnit4.class)
-public class DefinitionCommandTest extends ReferencesCommandTestBase<DefinitionTestGenerator> {
+public class DefinitionCommandTest extends ReferencesCommandTestBase<DefinitionTestGenerator, DefinitionParams> {
   @Test
   public void definitionJavaTest() {
     checkReferencesByDirectory("java/project-definition");
@@ -37,10 +36,8 @@ public class DefinitionCommandTest extends ReferencesCommandTestBase<DefinitionT
 
   @Override
   @Nullable
-  protected Set<? extends LocationLink> getActuals(@NotNull Object params) {
-    final DefinitionParams defParams = (DefinitionParams) params;
-    final var path = LspPath.fromLspUri(defParams.getTextDocument().getUri());
-    final var future = new FindDefinitionCommand(defParams.getPosition()).runAsync(getProject(), path);
+  protected Set<? extends LocationLink> getActuals(@NotNull DefinitionParams params) {
+    final var future = new FindDefinitionCommand().runAsync(getProject(), params.getTextDocument(), params.getPosition());
     var actual = TestUtil.getNonBlockingEdt(future, 50000);
     if (actual == null) {
       return null;

--- a/server/src/test/java/org/rri/ideals/server/references/DefinitionFromLibrarySourcesTest.java
+++ b/server/src/test/java/org/rri/ideals/server/references/DefinitionFromLibrarySourcesTest.java
@@ -48,7 +48,7 @@ public class DefinitionFromLibrarySourcesTest extends LightJavaCodeInsightFixtur
           LspPath.fromLocalPath(
               Paths.get(getTestDataPath()).resolve("src/DefinitionFromJar.java"));
 
-      final var future = new FindDefinitionCommand(new Position(3, 8)).runAsync(getProject(), path);
+      final var future = new FindDefinitionCommand().runAsync(getProject(), path.toLspUri(), new Position(3, 8));
       var actual = TestUtil.getNonBlockingEdt(future, 5000);
 
       assertNotNull(actual);

--- a/server/src/test/java/org/rri/ideals/server/references/DocumentHighlightCommandTest.java
+++ b/server/src/test/java/org/rri/ideals/server/references/DocumentHighlightCommandTest.java
@@ -3,6 +3,7 @@ package org.rri.ideals.server.references;
 import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
@@ -72,7 +73,7 @@ public class DocumentHighlightCommandTest extends ReferencesCommandTestBase {
   private void checkHighlight(@NotNull Set<@NotNull DocumentHighlight> answers,
                                 @NotNull Position pos,
                                 @NotNull LspPath path) {
-    final var future = new DocumentHighlightCommand(pos).runAsync(getProject(), path);
+    final var future = new DocumentHighlightCommand().runAsync(getProject(), path.toLspUri(), pos);
     final var lst = TestUtil.getNonBlockingEdt(future, 50000);
     assertNotNull(lst);
     assertEquals(answers, new HashSet<>(lst));
@@ -87,7 +88,7 @@ public class DocumentHighlightCommandTest extends ReferencesCommandTestBase {
   }
 
   @Override
-  protected @Nullable Object getActuals(@NotNull Object params) {
+  protected @Nullable Object getActuals(@NotNull TextDocumentPositionParams params) {
     return null;
   }
 }

--- a/server/src/test/java/org/rri/ideals/server/references/FindUsagesCommandTest.java
+++ b/server/src/test/java/org/rri/ideals/server/references/FindUsagesCommandTest.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.rri.ideals.server.LspPath;
 import org.rri.ideals.server.TestUtil;
 import org.rri.ideals.server.engine.TestEngine;
 import org.rri.ideals.server.generator.IdeaOffsetPositionConverter;
@@ -15,7 +14,7 @@ import org.rri.ideals.server.references.generators.FindUsagesTestGenerator;
 import java.util.HashSet;
 
 @RunWith(JUnit4.class)
-public class FindUsagesCommandTest extends ReferencesCommandTestBase<FindUsagesTestGenerator> {
+public class FindUsagesCommandTest extends ReferencesCommandTestBase<FindUsagesTestGenerator, ReferenceParams> {
   @Test
   public void testFindUsagesJava() {
     checkReferencesByDirectory("java/project-find-usages");
@@ -32,10 +31,8 @@ public class FindUsagesCommandTest extends ReferencesCommandTestBase<FindUsagesT
   }
 
   @Override
-  protected @Nullable Object getActuals(@NotNull Object params) {
-    final ReferenceParams refParams = (ReferenceParams) params;
-    final var path = LspPath.fromLspUri(refParams.getTextDocument().getUri());
-    final var future = new FindUsagesCommand(refParams.getPosition()).runAsync(getProject(), path);
+  protected @Nullable Object getActuals(@NotNull ReferenceParams params) {
+    final var future = new FindUsagesCommand().runAsync(getProject(), params.getTextDocument(), params.getPosition());
     return new HashSet<>(TestUtil.getNonBlockingEdt(future, 50000));
   }
 }

--- a/server/src/test/java/org/rri/ideals/server/references/ReferencesCommandTestBase.java
+++ b/server/src/test/java/org/rri/ideals/server/references/ReferencesCommandTestBase.java
@@ -1,5 +1,6 @@
 package org.rri.ideals.server.references;
 
+import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.rri.ideals.server.LspLightBasePlatformTestCase;
@@ -10,7 +11,7 @@ import org.rri.ideals.server.generator.TestGenerator;
 import java.nio.file.Paths;
 
 public abstract class ReferencesCommandTestBase<E extends TestGenerator<?
-    extends TestGenerator.Test>> extends LspLightBasePlatformTestCase {
+    extends TestGenerator.Test>, T extends TextDocumentPositionParams> extends LspLightBasePlatformTestCase {
   @Override
   protected String getTestDataPath() {
     return Paths.get("test-data/references").toAbsolutePath().toString();
@@ -18,7 +19,7 @@ public abstract class ReferencesCommandTestBase<E extends TestGenerator<?
 
   protected abstract @NotNull E getGenerator(@NotNull final TestEngine engine);
 
-  protected abstract @Nullable Object getActuals(@NotNull final Object params);
+  protected abstract @Nullable Object getActuals(@NotNull final T params);
 
   protected void checkReferencesByDirectory(@NotNull String testProjectRelativePath) {
       final var engine = new TestEngine(new IdeaTestFixture(myFixture));
@@ -29,7 +30,7 @@ public abstract class ReferencesCommandTestBase<E extends TestGenerator<?
         final var params = test.params();
         final var expected = test.expected();
 
-        final var actual = getActuals(params);
+        final var actual = getActuals((T) params);
 
         assertEquals(expected, actual);
       }

--- a/server/src/test/java/org/rri/ideals/server/references/TypeDefinitionCommandTest.java
+++ b/server/src/test/java/org/rri/ideals/server/references/TypeDefinitionCommandTest.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.rri.ideals.server.LspPath;
 import org.rri.ideals.server.TestUtil;
 import org.rri.ideals.server.engine.TestEngine;
 import org.rri.ideals.server.generator.IdeaOffsetPositionConverter;
@@ -16,7 +15,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @RunWith(JUnit4.class)
-public class TypeDefinitionCommandTest extends ReferencesCommandTestBase<TypeDefinitionTestGenerator> {
+public class TypeDefinitionCommandTest extends ReferencesCommandTestBase<TypeDefinitionTestGenerator, TypeDefinitionParams> {
   @Test
   public void testTypeDefinitionJava() {
     checkReferencesByDirectory("java/project-type-definition");
@@ -33,10 +32,8 @@ public class TypeDefinitionCommandTest extends ReferencesCommandTestBase<TypeDef
   }
 
   @Override
-  protected @Nullable Set<?> getActuals(@NotNull Object params) {
-    final TypeDefinitionParams typeDefParams = (TypeDefinitionParams) params;
-    final var path = LspPath.fromLspUri(typeDefParams.getTextDocument().getUri());
-    final var future = new FindTypeDefinitionCommand(typeDefParams.getPosition()).runAsync(getProject(), path);
+  protected @Nullable Set<?> getActuals(@NotNull TypeDefinitionParams params) {
+    final var future = new FindTypeDefinitionCommand().runAsync(getProject(), params.getTextDocument(), params.getPosition());
     var actual = TestUtil.getNonBlockingEdt(future, 50000);
     if (actual == null) {
       return null;

--- a/server/src/test/java/org/rri/ideals/server/rename/RenameCommandTestBase.java
+++ b/server/src/test/java/org/rri/ideals/server/rename/RenameCommandTestBase.java
@@ -48,7 +48,7 @@ abstract class RenameCommandTestBase extends LspLightBasePlatformTestCase {
       answer = new WorkspaceEdit(Stream.concat(changedEdits.stream(), changedOperations.stream()).toList());
     }
 
-    final var future = new RenameCommand(pos, newName).runAsync(getProject(), renameTestPath);
+    final var future = new RenameCommand(newName).runAsync(getProject(), renameTestPath.toLspUri(), pos);
     final var result = TestUtil.getNonBlockingEdt(future, 50000);
 
     assertNotNull(result);


### PR DESCRIPTION
- Injects the editor in ExecutorContext instead of create it for each lsp command
- Dispose automatically the editor when the service call is completed