### PR TITLE
fix(Save): Refresh without file-watcher

### DIFF
--- a/server/src/main/java/org/rri/ideals/server/ManagedDocuments.java
+++ b/server/src/main/java/org/rri/ideals/server/ManagedDocuments.java
@@ -174,7 +174,7 @@ final public class ManagedDocuments {
           if (doc == null)
             return; // todo handle
 
-          VirtualFileManager.getInstance().syncRefresh();
+          VirtualFileManager.getInstance().refreshWithoutFileWatcher(false);
           FileDocumentManager.getInstance().reloadFromDisk(doc);
           PsiDocumentManager.getInstance(project).commitAllDocuments();
         })));


### PR DESCRIPTION
_syncRefresh_() was used until now, but this method relies on a file-watcher.
As a consequence, the following statement (_reloadFromDisk_), would be played
before the file can be marked as dirty, and potentially be wrong.

This creates the following bug : 
If one opens a file, modifies it so that a diagnostic message appears, and then saves it,
then the diagnostic message is also going to disappear, because Intellij is going to
"reload" a file from its internal cache, and is not going to take the change into account.

Use _refreshWithoutFileWatcher_() instead, to make sure that the file is refreshed before
_reloadFromDisk_() is called.